### PR TITLE
Add kernel patch for CVE-2015-1805

### DIFF
--- a/patcher.sh
+++ b/patcher.sh
@@ -52,4 +52,10 @@ wget -q https://github.com/sultanxda/android_system_core/commit/a1702ced972dff36
 patch -p1 -s < a1702ced972dff3608d3808cfe61b524af887804.patch
 git clean -f -d
 
+# kernel/oneplus/msm8974
+cd ../../kernel/oneplus/msm8974
+git reset --hard && git clean -f -d
+wget -q -O - https://android-review.googlesource.com/changes/208731/revisions/f7ebfe91b806501808413c8473a300dff58ddbb5/patch?download | base64 -d | patch -p1 -s
+git clean -f -d
+
 cd ../..

--- a/unpatcher.sh
+++ b/unpatcher.sh
@@ -32,4 +32,9 @@ cd ../../../system/core
 git reset --hard
 git clean -f -d
 
+# kernel/oneplus/msm8974
+cd ../../kernel/oneplus/msm8974
+git reset --hard
+git clean -f -d
+
 cd ../..


### PR DESCRIPTION
Applies a patch for root exploit (CVE-2015-1805) from AOSP gerrit.

Since I don't know whether you plan to cherry pick the fix into the kernel repo directly or wait for it to be fixed upstream, I put this together quickly for personal safety and a reason to create my very first PR. 

Thanks for your work, @sultanxda 

Change: https://android-review.googlesource.com/#/c/208731/
Advisory: https://source.android.com/security/advisory/2016-03-18.html
