### PR TITLE
Add WireGuard to kernel via patcher interface

### DIFF
--- a/patcher.sh
+++ b/patcher.sh
@@ -5,6 +5,7 @@
 ROM_TREE=$PWD
 PATCHER_PATH=$ROM_TREE/patcher
 SULTAN=$PATCHER_PATH/sultan
+ZX2C4=$PATCHER_PATH/zx2c4
 CUSTOM=$PATCHER_PATH/custom
 
 # Clean up first
@@ -15,6 +16,8 @@ git clean -f -d && git reset --hard
 cd $ROM_TREE/frameworks/base
 git clean -f -d && git reset --hard
 cd $ROM_TREE/frameworks/native
+git clean -f -d && git reset --hard
+cd $ROM_TREE/kernel/oneplus/msm8996
 git clean -f -d && git reset --hard
 cd $ROM_TREE/packages/apps/Eleven
 git clean -f -d && git reset --hard
@@ -44,6 +47,10 @@ patch -d packages/apps/LockClock		-p1 -s -N --no-backup-if-mismatch < $SULTAN/pa
 patch -d system/core				-p1 -s -N --no-backup-if-mismatch < $SULTAN/system-core0.patch
 patch -d system/core				-p1 -s -N --no-backup-if-mismatch < $SULTAN/system-core1.patch
 patch -d vendor/cm				-p1 -s -N --no-backup-if-mismatch < $SULTAN/vendor-cm0.patch
+
+### zx2c4's patches
+$ZX2C4/wireguard-fetch.sh || rm -f $ZX2C4/wireguard-src.patch
+patch -d kernel/oneplus/msm8996			-p1 -s -N --no-backup-if-mismatch < $ZX2C4/wireguard-src.patch
 
 ### Custom patches
 patch -d packages/apps/Gallery2			-p1 -s -N --no-backup-if-mismatch < $CUSTOM/packages-apps-Gallery20.patch

--- a/unpatcher.sh
+++ b/unpatcher.sh
@@ -11,6 +11,8 @@ cd $ROM_TREE/frameworks/base
 git clean -f -d && git reset --hard
 cd $ROM_TREE/frameworks/native
 git clean -f -d && git reset --hard
+cd $ROM_TREE/kernel/oneplus/msm8996
+git clean -f -d && git reset --hard
 cd $ROM_TREE/packages/apps/Eleven
 git clean -f -d && git reset --hard
 cd $ROM_TREE/packages/apps/Gallery2

--- a/zx2c4/.gitignore
+++ b/zx2c4/.gitignore
@@ -1,0 +1,1 @@
+wireguard-src.patch

--- a/zx2c4/wireguard-fetch.sh
+++ b/zx2c4/wireguard-fetch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+DEST="$(readlink -f "$(dirname "$0")")"
+# Download at most once a day
+[[ $(( $(date +%s) - $(stat -c %Y "$DEST/wireguard-src.patch" 2>/dev/null || echo 0) )) -gt 86400 ]] || exit 0
+
+temp="$(mktemp -d)"
+trap "rm -rf '$temp'; exit" INT TERM EXIT
+
+[[ $(curl https://git.zx2c4.com/WireGuard/refs/) =~ snapshot/(WireGuard-[0-9.]+\.tar\.xz) ]]
+curl "https://git.zx2c4.com/WireGuard/snapshot/${BASH_REMATCH[1]}" | tar -C "$temp" -xJf -
+
+# Android's build system doesn't like these friendly warnings
+sed -i '/^#warning/d' "$temp"/WireGuard-*/src/compat/compat.h
+# Android's ancient gcc can't actually support int128 __multi3 in kernel compiles
+sed -i 's/__SIZEOF_INT128__/__SIZEOF_INT128__disabled/' "$temp"/WireGuard-*/src/crypto/curve25519.c
+
+"$temp"/WireGuard-*/contrib/kernel-tree/create-patch.sh > "$DEST/wireguard-src.patch"
+exit 0


### PR DESCRIPTION
This will allow WireGuard to be updated trivially whenever you makes new releases, without the actual source invading the kernel tree. The purpose is so that your image becomes a useful place for developing WireGuard for Android during GSoC and beyond. This increases the kernel image by a trivial size, and when not in direct use does not add any running code or bloat of any kind.

@sultanxda  @smaeul