### PR TITLE
wireguard: #warning prompt gone upstream

### DIFF
--- a/zx2c4/wireguard-fetch.sh
+++ b/zx2c4/wireguard-fetch.sh
@@ -11,8 +11,6 @@ trap "rm -rf '$temp'; exit" INT TERM EXIT
 [[ $(curl https://git.zx2c4.com/WireGuard/refs/) =~ snapshot/(WireGuard-[0-9.]+\.tar\.xz) ]]
 curl "https://git.zx2c4.com/WireGuard/snapshot/${BASH_REMATCH[1]}" | tar -C "$temp" -xJf -
 
-# Android's build system doesn't like these friendly warnings
-sed -i '/^#warning/d' "$temp"/WireGuard-*/src/compat/compat.h
 # Android's ancient gcc can't actually support int128 __multi3 in kernel compiles
 sed -i 's/__SIZEOF_INT128__/__SIZEOF_INT128__disabled/' "$temp"/WireGuard-*/src/crypto/curve25519.c
 


### PR DESCRIPTION
The latest snapshot doesn't have this directive anymore.