### PR TITLE
wireguard: fix up faulty snapshot patcher

### DIFF
--- a/zx2c4/wireguard-fetch.sh
+++ b/zx2c4/wireguard-fetch.sh
@@ -9,7 +9,10 @@ temp="$(mktemp -d)"
 trap "rm -rf '$temp'; exit" INT TERM EXIT
 
 [[ $(curl https://git.zx2c4.com/WireGuard/refs/) =~ snapshot/(WireGuard-[0-9.]+\.tar\.xz) ]]
-curl "https://git.zx2c4.com/WireGuard/snapshot/${BASH_REMATCH[1]}" | tar -C "$temp" -xJf -
+curl -L "https://git.zx2c4.com/WireGuard/snapshot/${BASH_REMATCH[1]}" | tar -C "$temp" -xJf -
+
+# Account for mega derp in latest snapshot. This should be removed whenever that isn't the most recent snapshot any more.
+[[ ${BASH_REMATCH[1]} == WireGuard-0.0.20171001.tar.xz ]] && curl -L -o "$temp"/WireGuard-*/contrib/kernel-tree/create-patch.sh https://git.zx2c4.com/WireGuard/plain/contrib/kernel-tree/create-patch.sh
 
 # Android's ancient gcc can't actually support int128 __multi3 in kernel compiles
 sed -i 's/__SIZEOF_INT128__/__SIZEOF_INT128__disabled/' "$temp"/WireGuard-*/src/crypto/curve25519.c


### PR DESCRIPTION
I forgot to update the paths in create-patch.sh of the latest snapshot,
which means this will likely produce a bad patch. So, fixing it up here
as a stop-gap measure, so that Sultan doesn't freak out when my patch
ruins his kernel compiles.

This should be reverted as soon as a new snapshot upstream is released.