### PR TITLE
wireguard-fetch: no need to patch out __int128 support

### DIFF
--- a/zx2c4/wireguard-fetch.sh
+++ b/zx2c4/wireguard-fetch.sh
@@ -11,8 +11,5 @@ trap "rm -rf '$temp'; exit" INT TERM EXIT
 [[ $(curl https://git.zx2c4.com/WireGuard/refs/) =~ snapshot/(WireGuard-[0-9.]+\.tar\.xz) ]]
 curl "https://git.zx2c4.com/WireGuard/snapshot/${BASH_REMATCH[1]}" | tar -C "$temp" -xJf -
 
-# Android's ancient gcc can't actually support int128 __multi3 in kernel compiles
-sed -i 's/__SIZEOF_INT128__/__SIZEOF_INT128__disabled/' "$temp"/WireGuard-*/src/crypto/curve25519.c
-
 "$temp"/WireGuard-*/contrib/kernel-tree/create-patch.sh > "$DEST/wireguard-src.patch"
 exit 0


### PR DESCRIPTION
As of [1], WireGuard now won't enable this unless the architecture
actually supports it. Gcc versions 5 and up do support this [2], and so
support to upstream has been proposed [3].

In all cases, for the next WireGuard snapshot, we no longer need this
sed in the fetch script.

[1] https://git.zx2c4.com/WireGuard/commit/?id=c22addbd7d2db895723dd9cc331344276bfa1d0a
[2] https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=d1ae7bb994f49316f6f63e6173f2931e837a351d
[3] http://lists.infradead.org/pipermail/linux-arm-kernel/2017-October/539943.html