### PR TITLE
Some script cleanup

### DIFF
--- a/patcher.sh
+++ b/patcher.sh
@@ -1,63 +1,58 @@
 #!/bin/sh
 
 # Apply these patches before compilation:
-
-ROM_TREE=$PWD
-PATCHER_PATH=$ROM_TREE/patcher
-SULTAN=$PATCHER_PATH/sultan
-ZX2C4=$PATCHER_PATH/zx2c4
-CUSTOM=$PATCHER_PATH/custom
+CUSTOM=$PWD/patcher/custom
+SULTAN=$PWD/patcher/sultan
+ZX2C4=$PWD/patcher/zx2c4
 
 # Clean up first
-cd $ROM_TREE/build
-git clean -f -d && git reset --hard
-cd $ROM_TREE/device/oppo/common
-git clean -f -d && git reset --hard
-cd $ROM_TREE/frameworks/av
-git clean -f -d && git reset --hard
-cd $ROM_TREE/frameworks/base
-git clean -f -d && git reset --hard
-cd $ROM_TREE/frameworks/native
-git clean -f -d && git reset --hard
-cd $ROM_TREE/kernel/oneplus/msm8996
-git clean -f -d && git reset --hard
-cd $ROM_TREE/packages/apps/Gallery2
-git clean -f -d && git reset --hard
-cd $ROM_TREE/packages/apps/LockClock
-git clean -f -d && git reset --hard
-cd $ROM_TREE/packages/apps/Settings
-git clean -f -d && git reset --hard
-cd $ROM_TREE/system/core
-git clean -f -d && git reset --hard
-cd $ROM_TREE/vendor/cm
-git clean -f -d && git reset --hard
-
-cd $ROM_TREE
+git -C build				clean -dfqx
+git -C build				reset -q --hard
+git -C device/oppo/common		clean -dfqx
+git -C device/oppo/common		reset -q --hard
+git -C frameworks/av			clean -dfqx
+git -C frameworks/av			reset -q --hard
+git -C frameworks/base			clean -dfqx
+git -C frameworks/base			reset -q --hard
+git -C frameworks/native		clean -dfqx
+git -C frameworks/native		reset -q --hard
+git -C kernel/oneplus/msm8996		clean -dfqx
+git -C kernel/oneplus/msm8996		reset -q --hard
+git -C packages/apps/Gallery2		clean -dfqx
+git -C packages/apps/Gallery2		reset -q --hard
+git -C packages/apps/LockClock		clean -dfqx
+git -C packages/apps/LockClock		reset -q --hard
+git -C packages/apps/Settings		clean -dfqx
+git -C packages/apps/Settings		reset -q --hard
+git -C system/core			clean -dfqx
+git -C system/core			reset -q --hard
+git -C vendor/cm			clean -dfqx
+git -C vendor/cm			reset -q --hard
 
 ### Sultan's patches
-patch -d build					-p1 -s -N --no-backup-if-mismatch < $SULTAN/build0.patch
-patch -d device/oppo/common			-p1 -s -N --no-backup-if-mismatch < $SULTAN/device-oppo-common0.patch
-patch -d frameworks/av				-p1 -s -N --no-backup-if-mismatch < $SULTAN/frameworks-av0.patch
-patch -d frameworks/base			-p1 -s -N --no-backup-if-mismatch < $SULTAN/frameworks-base0.patch
-patch -d frameworks/base			-p1 -s -N --no-backup-if-mismatch < $SULTAN/frameworks-base1.patch
-patch -d frameworks/base			-p1 -s -N --no-backup-if-mismatch < $SULTAN/frameworks-base2.patch
-patch -d frameworks/base			-p1 -s -N --no-backup-if-mismatch < $SULTAN/frameworks-base3.patch
-patch -d frameworks/base			-p1 -s -N --no-backup-if-mismatch < $SULTAN/frameworks-base4.patch
-patch -d frameworks/native			-p1 -s -N --no-backup-if-mismatch < $SULTAN/frameworks-native0.patch
-patch -d packages/apps/LockClock		-p1 -s -N --no-backup-if-mismatch < $SULTAN/packages-apps-LockClock0.patch
-patch -d packages/apps/Settings			-p1 -s -N --no-backup-if-mismatch < $SULTAN/packages-apps-Settings0.patch
-patch -d system/core				-p1 -s -N --no-backup-if-mismatch < $SULTAN/system-core0.patch
-patch -d system/core				-p1 -s -N --no-backup-if-mismatch < $SULTAN/system-core1.patch
-patch -d system/core				-p1 -s -N --no-backup-if-mismatch < $SULTAN/system-core2.patch
-patch -d vendor/cm				-p1 -s -N --no-backup-if-mismatch < $SULTAN/vendor-cm0.patch
-patch -d vendor/cm				-p1 -s -N --no-backup-if-mismatch < $SULTAN/vendor-cm1.patch
+git -C build				apply $SULTAN/build0.patch
+git -C device/oppo/common		apply $SULTAN/device-oppo-common0.patch
+git -C frameworks/av			apply $SULTAN/frameworks-av0.patch
+git -C frameworks/base			apply $SULTAN/frameworks-base0.patch
+git -C frameworks/base			apply $SULTAN/frameworks-base1.patch
+git -C frameworks/base			apply $SULTAN/frameworks-base2.patch
+git -C frameworks/base			apply $SULTAN/frameworks-base3.patch
+git -C frameworks/base			apply $SULTAN/frameworks-base4.patch
+git -C frameworks/native		apply $SULTAN/frameworks-native0.patch
+git -C packages/apps/LockClock		apply $SULTAN/packages-apps-LockClock0.patch
+git -C packages/apps/Settings		apply $SULTAN/packages-apps-Settings0.patch
+git -C system/core			apply $SULTAN/system-core0.patch
+git -C system/core			apply $SULTAN/system-core1.patch
+git -C system/core			apply $SULTAN/system-core2.patch
+git -C vendor/cm			apply $SULTAN/vendor-cm0.patch
+git -C vendor/cm			apply $SULTAN/vendor-cm1.patch
 
 ### zx2c4's patches
 $ZX2C4/wireguard-fetch.sh || rm -f $ZX2C4/wireguard-src.patch
-patch -d kernel/oneplus/msm8996			-p1 -s -N --no-backup-if-mismatch < $ZX2C4/wireguard-src.patch
+git -C kernel/oneplus/msm8996		apply $ZX2C4/wireguard-src.patch
 
 ### Custom patches
-patch -d frameworks/av				-p1 -s -N --no-backup-if-mismatch < $CUSTOM/frameworks-av0.patch
-patch -d packages/apps/Gallery2			-p1 -s -N --no-backup-if-mismatch < $CUSTOM/packages-apps-Gallery20.patch
-patch -d packages/apps/Gallery2			-p1 -s -N --no-backup-if-mismatch < $CUSTOM/packages-apps-Gallery21.patch
-patch -d packages/apps/Gallery2			-p1 -s -N --no-backup-if-mismatch < $CUSTOM/packages-apps-Gallery22.patch
+git -C frameworks/av			apply $CUSTOM/frameworks-av0.patch
+git -C packages/apps/Gallery2		apply $CUSTOM/packages-apps-Gallery20.patch
+git -C packages/apps/Gallery2		apply $CUSTOM/packages-apps-Gallery21.patch
+git -C packages/apps/Gallery2		apply $CUSTOM/packages-apps-Gallery22.patch

--- a/sultan/frameworks-av0.patch
+++ b/sultan/frameworks-av0.patch
@@ -14,7 +14,7 @@ Change-Id: I932f7463ea8ab9786806b430aa3e3f3a09d99423
  2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/include/media/MediaProfiles.h b/include/media/MediaProfiles.h
-index a45dc58..d0fdb3f 100755
+index a45dc58..d0fdb3f 100644
 --- a/include/media/MediaProfiles.h
 +++ b/include/media/MediaProfiles.h
 @@ -71,7 +71,9 @@ enum camcorder_quality {
@@ -29,7 +29,7 @@ index a45dc58..d0fdb3f 100755
  
  enum video_decoder {
 diff --git a/media/libmedia/MediaProfiles.cpp b/media/libmedia/MediaProfiles.cpp
-index 52da7ed..d85ba35 100755
+index 52da7ed..d85ba35 100644
 --- a/media/libmedia/MediaProfiles.cpp
 +++ b/media/libmedia/MediaProfiles.cpp
 @@ -105,6 +105,8 @@ const MediaProfiles::NameToTagMap MediaProfiles::sCamcorderQualityNameMap[] = {

--- a/sultan/frameworks-base1.patch
+++ b/sultan/frameworks-base1.patch
@@ -75,4 +75,4 @@ index f10b982..57bea43 100644
 +
          // Our own stack trace to append
          StringWriter sw = new StringWriter();
-         PrintWriter pw = new FastPrintWriter(sw, false, 256);
+         sw.append("# via Binder call with stack:\n");

--- a/unpatcher.sh
+++ b/unpatcher.sh
@@ -1,27 +1,25 @@
 #!/bin/sh
 
-ROM_TREE=$PWD
-
 # Clean up
-cd $ROM_TREE/build
-git clean -f -d && git reset --hard
-cd $ROM_TREE/frameworks/av
-git clean -f -d && git reset --hard
-cd $ROM_TREE/frameworks/base
-git clean -f -d && git reset --hard
-cd $ROM_TREE/frameworks/native
-git clean -f -d && git reset --hard
-cd $ROM_TREE/kernel/oneplus/msm8996
-git clean -f -d && git reset --hard
-cd $ROM_TREE/packages/apps/Gallery2
-git clean -f -d && git reset --hard
-cd $ROM_TREE/packages/apps/LockClock
-git clean -f -d && git reset --hard
-cd $ROM_TREE/packages/apps/Settings
-git clean -f -d && git reset --hard
-cd $ROM_TREE/system/core
-git clean -f -d && git reset --hard
-cd $ROM_TREE/vendor/cm
-git clean -f -d && git reset --hard
-
-cd $ROM_TREE
+git -C build				clean -dfqx
+git -C build				reset -q --hard
+git -C device/oppo/common		clean -dfqx
+git -C device/oppo/common		reset -q --hard
+git -C frameworks/av			clean -dfqx
+git -C frameworks/av			reset -q --hard
+git -C frameworks/base			clean -dfqx
+git -C frameworks/base			reset -q --hard
+git -C frameworks/native		clean -dfqx
+git -C frameworks/native		reset -q --hard
+git -C kernel/oneplus/msm8996		clean -dfqx
+git -C kernel/oneplus/msm8996		reset -q --hard
+git -C packages/apps/Gallery2		clean -dfqx
+git -C packages/apps/Gallery2		reset -q --hard
+git -C packages/apps/LockClock		clean -dfqx
+git -C packages/apps/LockClock		reset -q --hard
+git -C packages/apps/Settings		clean -dfqx
+git -C packages/apps/Settings		reset -q --hard
+git -C system/core			clean -dfqx
+git -C system/core			reset -q --hard
+git -C vendor/cm			clean -dfqx
+git -C vendor/cm			reset -q --hard


### PR DESCRIPTION
Instead of changing directories all of the time, use `git`'s `-C` option.
Also use `git apply` to apply patches (you could add `--recount` for more input flexibility).